### PR TITLE
More Pythonic way to handle exceptions and exit codes.

### DIFF
--- a/patsy/__main__.py
+++ b/patsy/__main__.py
@@ -72,7 +72,6 @@ def main() -> None:
     logging.info(f"Command ran: {args.cmd_name}")
 
     load_dotenv()
-    status_code: int = 0
 
     try:
         gateway = DbGateway(args)
@@ -85,39 +84,43 @@ def main() -> None:
 
     except DatabaseNotSetError:
         logging.error('The "-d" argument was not set nor was the "PATSY_DATABASE" environment variable.')
-        status_code = 1
+        sys.exit(1)
 
     except OperationalError as e:
         # Some error messages created contain multiple lines and tabs
         # I'm removing them so that splunk has an easier time parsing them
         error = str(e.orig).replace('\n', ' ').replace('\t', '')
         logging.error(error)
-        status_code = 1
+        sys.exit(1)
 
     except InvalidStatusCodeError:
         logging.error(
             'An error occurred when using the API. This could be due to the servers, '
             'or the headers provided may be incorrect.'
         )
-        status_code = 1
+        sys.exit(1)
 
     except MissingHeadersError:
         logging.error(
             'The headers to access the ApTrust API were not set. '
             'Provide them as an argument to the sync command or as environment variables in the shell.'
         )
-        status_code = 1
+        sys.exit(1)
 
     except InvalidTimeError:
         logging.error(
             'The time arguments provided conflict with each other. '
             'Make sure that the "timeafter" argument is a date that comes before the "timebefore" argument.'
         )
-        status_code = 1
+        sys.exit(1)
+
+    else:
+        # no errors, exit with a normal status
+        sys.exit(0)
 
     finally:
+        # this will always get called, even after the calls to sys.exit()
         logging.debug("Done")
-        sys.exit(status_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because internally sys.exit is just raising a SystemExit exception, when it is wrapped in a try clause the finally block will always be evaluated before the program continues to exit with the code given to sys.exit().